### PR TITLE
Use tesseract/current-language as the initial language

### DIFF
--- a/tesseract.el
+++ b/tesseract.el
@@ -68,8 +68,8 @@
 (defun tesseract-change-language ()
   "Change the language based on the options given by tesseract/list-languages."
   (interactive)
-  (let((options (tesseract/list-languages)))
-    (setq tesseract/current-language (completing-read "Language:" options nil t "eng" 'tesseract/language-history))))
+  (let ((options (tesseract/list-languages)))
+    (setq tesseract/current-language (completing-read "Language: " options nil t tesseract/current-language 'tesseract/language-history))))
 
 (require 'doc-view)
 


### PR DESCRIPTION
The `tesseract-change-language` function uses `"eng"` as the initial choice, regardless of the current language or default language setting. This appears unintuitive. A more sensible initial choice may be the value of `current-language`, and this PR applies a trivial fix.